### PR TITLE
cythonizing forward

### DIFF
--- a/pyhacrf/algorithms.pyx
+++ b/pyhacrf/algorithms.pyx
@@ -1,25 +1,31 @@
 from collections import defaultdict
 import numpy as np
+cimport numpy as np
+from numpy.math cimport logaddexp
 
-
-def forward(lattice, x_dot_parameters):
+cpdef dict forward(list lattice, np.ndarray[double, ndim=3] x_dot_parameters):
     """ Helper to calculate the forward weights.  """
-    alpha = defaultdict(lambda: -np.inf)
+    cdef dict alpha = {}
+
+    cdef int i,j,s,i0,j0,s0,i1,j1,s1,edge_parameter_index
+    cdef float edge_potential
+    cdef tuple node
 
     for node in lattice:
         if len(node) == 3:
             i, j, s = node
             if i == 0 and j == 0:
-                alpha[node] = x_dot_parameters[i, j, s]
+                alpha[(i, j, s)] = x_dot_parameters[i, j, s]
             else:
-                alpha[node] += x_dot_parameters[i, j, s]
+                alpha[(i, j, s)] += x_dot_parameters[i, j, s]
         else:
             i0, j0, s0, i1, j1, s1, edge_parameter_index = node  # Actually an edge in this case
             # Use the features at the destination of the edge.
             edge_potential = (x_dot_parameters[i1, j1, edge_parameter_index]
                               + alpha[(i0, j0, s0)])
             alpha[node] = edge_potential
-            alpha[(i1, j1, s1)] = np.logaddexp(alpha[(i1, j1, s1)], edge_potential)
+            alpha[(i1, j1, s1)] = logaddexp(alpha.get((i1, j1, s1), -np.inf), 
+                                            edge_potential)
     return alpha
 
 

--- a/pyhacrf/pyhacrf.py
+++ b/pyhacrf/pyhacrf.py
@@ -6,7 +6,7 @@
 import numpy as np
 import lbfgs
 from collections import defaultdict
-from algorithms import forward, backward
+from .algorithms import forward, backward
 
 
 class Hacrf(object):

--- a/pyhacrf/pyhacrf.py
+++ b/pyhacrf/pyhacrf.py
@@ -426,9 +426,9 @@ class _Model(object):
                 final_lattice.append(node)
             elif len(node) > 3 :
                 source_node, dest_node = node[0:3], node[3:6]
-                #if dest_node in visited_nodes:
-                visited_nodes.add(source_node)
-                final_lattice.append(node)
+                if dest_node in visited_nodes:
+                    visited_nodes.add(source_node)
+                    final_lattice.append(node)
 
         return list(reversed(final_lattice))
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,34 @@
-from distutils.core import setup
+from setuptools import setup, Extension
 from codecs import open
 from os import path
 from Cython.Build import cythonize
+from numpy.distutils.misc_util import get_info
+
+# from Michael Hoffman's http://www.ebi.ac.uk/~hoffman/software/sunflower/
+class NumpyExtension(Extension):
+
+    def __init__(self, *args, **kwargs):
+        Extension.__init__(self, *args, **kwargs)
+
+        self._include_dirs = self.include_dirs
+        del self.include_dirs  # restore overwritten property
+
+    # warning: Extension is a classic class so it's not really read-only
+
+    def get_include_dirs(self):
+        from numpy import get_include
+        return self._include_dirs + [get_include()]
+
+    def set_include_dirs(self, value):
+        self._include_dirs = value
+
+    def del_include_dirs(self):
+        pass
+        
+    include_dirs = property(get_include_dirs, 
+                            set_include_dirs, 
+                            del_include_dirs)
+
 
 here = path.abspath(path.dirname(__file__))
 
@@ -14,7 +41,9 @@ setup(
     version='0.0.6',
     packages=['pyhacrf'],
     install_requires=['numpy>=1.9', 'PyLBFGS>=0.1.3'],
-    ext_modules=cythonize('pyhacrf/algorithms.pyx'),
+    ext_modules=[NumpyExtension('pyhacrf.algorithms', 
+                                ['pyhacrf/algorithms.c'],
+                                **get_info('npymath'))],
     url='https://github.com/dirko/pyhacrf',
     download_url='https://github.com/dirko/pyhacrf/tarball/0.0.6',
     license='BSD',


### PR DESCRIPTION
Wanted to share this with you to get a sense of the opportunities for speedup. This is not something you probably want to merge.

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     4391    0.718    0.000   58.747    0.013 pyhacrf.py:124(predict_proba)
     4391    0.255    0.000   52.379    0.012 pyhacrf.py:326(__init__)
     4391   33.744    0.008   52.124    0.012 pyhacrf.py:385(_build_lattice)
     4390    0.045    0.000    5.565    0.001 pyhacrf.py:356(predict)
     4390    0.122    0.000    5.267    0.001 pyhacrf.py:362(_forward_probabilities)
     4390    0.007    0.000    5.142    0.001 pyhacrf.py:376(_forward)
     4390    5.134    0.001    5.134    0.001 {pyhacrf.algorithms.forward}
     4391    0.005    0.000    3.314    0.001 pyhacrf.py:275(fit_transform)
     4391    0.008    0.000    3.309    0.001 pyhacrf.py:291(transform)
     4391    2.506    0.001    3.302    0.001 pyhacrf.py:307(_extract_features)
```

If we changed alpha from a dict to a numpy array. 

```
     3059    0.324    0.000   41.912    0.014 pyhacrf.py:124(predict_proba)
     3059    0.217    0.000   40.386    0.013 pyhacrf.py:326(__init__)
     3059   25.773    0.008   40.169    0.013 pyhacrf.py:385(_build_lattice)
     3059    0.005    0.000    2.604    0.001 pyhacrf.py:275(fit_transform)
     3059    0.007    0.000    2.599    0.001 pyhacrf.py:291(transform)
     3059    1.958    0.001    2.592    0.001 pyhacrf.py:307(_extract_features)
     3058    0.046    0.000    1.130    0.000 pyhacrf.py:356(predict)
     3058    0.112    0.000    0.881    0.000 pyhacrf.py:362(_forward_probabilities)
     3058    0.006    0.000    0.766    0.000 pyhacrf.py:376(_forward)
     3058    0.759    0.000    0.759    0.000 {pyhacrf.algorithms.forward}
```
