### PR TITLE
Building Mac OS X and window wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ after_success:
     - echo index-servers = pypi                        >> ~/.pypirc
     - echo [pypi]                                      >> ~/.pypirc
     - echo repository=https://pypi.python.org/pypi     >> ~/.pypirc
-    - echo username=zope.wheelbuilder                  >> ~/.pypirc
+    - echo username=Dirko.Coetsee                      >> ~/.pypirc
     - echo password=$PYPIPASSWORD                      >> ~/.pypirc
     - if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then pip install twine; fi
     - if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then python setup.py bdist_wheel; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+language: python
+sudo: false
+matrix:
+    include:
+        - os: linux
+          python: 2.7
+        - os: linux
+          python: 3.4
+        - os: osx
+          language: generic
+          env: TERRYFY_PYTHON='homebrew 2'
+        - os: osx
+          language: generic
+          env: TERRYFY_PYTHON='homebrew 3'
+before_install:
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git clone https://github.com/MacPython/terryfy; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source terryfy/travis_tools.sh; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then get_python_environment $TERRYFY_PYTHON venv; fi
+    - if [[ "$TERRYFY_PYTHON" == "homebrew 3" ]]; then alias pip=`which pip3` ; fi
+install:
+    - pip install -r requirements.txt
+    - cython pyhacrf/algorithms.pyx
+    - pip install .
+script:
+    - nosetests
+notifications:
+    email: false
+after_success:
+    - echo [distutils]                                  > ~/.pypirc
+    - echo index-servers = pypi                        >> ~/.pypirc
+    - echo [pypi]                                      >> ~/.pypirc
+    - echo repository=https://pypi.python.org/pypi     >> ~/.pypirc
+    - echo username=zope.wheelbuilder                  >> ~/.pypirc
+    - echo password=$PYPIPASSWORD                      >> ~/.pypirc
+    - if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then pip install twine; fi
+    - if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then python setup.py bdist_wheel; fi
+    - if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then twine upload dist/*; fi
+
+env:
+    global:
+        secure: J8y6Yv7w8z1pch0RzXquJwNG5ln78/rqo21TfnwEtymQnLO10jLw+YafwQozBlI8SWpU+k/C7UQCwtMAFEvBfgnToh+3fR70kX7qDvte9DKsbo2qUBAg/Pw/mVYHcpWVFW7wj9YVYxoe4Hk1vmmLuDxYu81/c75nxJljH5xdo+0=
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ deploy_script:
   - echo     pypi                                    >> %USERPROFILE%\\.pypirc
   - echo [pypi]                                      >> %USERPROFILE%\\.pypirc
   - echo repository=https://pypi.python.org/pypi     >> %USERPROFILE%\\.pypirc
-  - echo username=zope.wheelbuilder                  >> %USERPROFILE%\\.pypirc
+  - echo username=Dirko.Coetsee                      >> %USERPROFILE%\\.pypirc
   - echo password=%password%                         >> %USERPROFILE%\\.pypirc
   - set HOME=%USERPROFILE%
   - pip install wheel twine

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,38 @@
+environment:
+  password:
+    secure: uOcv5TOm/CgwOmiLQhNX+g==
+
+  matrix:
+    - python : 27
+    - python : 27-x64
+    - python : 34
+    - python : 34-x64
+
+install:
+  - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"
+  - echo "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 > "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64\vcvars64.bat"
+  - pip install -r requirements.txt
+  - cython pyhacrf/algorithms.pyx
+  - pip install -e . 
+
+build: false
+
+test_script:
+  - nosetests
+
+on_success:
+  - echo Build succesful!
+
+deploy_script:
+  - echo [distutils]                                  > %USERPROFILE%\\.pypirc
+  - echo index-servers =                             >> %USERPROFILE%\\.pypirc
+  - echo     pypi                                    >> %USERPROFILE%\\.pypirc
+  - echo [pypi]                                      >> %USERPROFILE%\\.pypirc
+  - echo repository=https://pypi.python.org/pypi     >> %USERPROFILE%\\.pypirc
+  - echo username=zope.wheelbuilder                  >> %USERPROFILE%\\.pypirc
+  - echo password=%password%                         >> %USERPROFILE%\\.pypirc
+  - set HOME=%USERPROFILE%
+  - pip install wheel twine
+  - ps: if($env:APPVEYOR_REPO_TAG -eq $TRUE) { python -W ignore setup.py bdist_wheel bdist_egg && twine upload dist/* }
+
+deploy : on

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 cython>=0.22
+nose


### PR DESCRIPTION
These scripts will 
- test pyhacrf on linux, mac os x, and windows
- on tagged commites, build and deploy wheels to pypi

@dirko, you'll need to 
1. enable travis ci for this repo: https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A
2. enable appveyor for this repo: https://www.appveyor.com/docs
